### PR TITLE
Check for parent before getting ID. 

### DIFF
--- a/Helper/ApiClient.php
+++ b/Helper/ApiClient.php
@@ -35,10 +35,10 @@ class ApiClient
     $products = $order->getAllVisibleItems(); //filter out simple products
     $products_arr = array();
     foreach ($products as $item) {
-      $full_product = $this->_productRepository->get($item->getSku()); 
-      $parentId = $item->getProduct()->getId(); 
-      if (!empty($parentId)) {
-              $full_product = $this->_productRepository->getById($parentId);
+      $full_product = $this->_productRepository->get($item->getSku());
+      $parent = $item->getProduct();
+      if ($parent && !empty($parent->getId())) {
+        $full_product = $this->_productRepository->getById($parent->getId());
       }
       $product_data = array();
       $product_data['name'] = $full_product->getName();


### PR DESCRIPTION
This is a fix for issue #62 . Checks first for `$item->getProduct()` to be null before attempting to run `getId()`. In my experience this failed when processing shipments for orders with certain products. 