### PR TITLE
add namespace to bottomline and widget_div blocks

### DIFF
--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -7,12 +7,12 @@
 	    </referenceContainer>
 
         <referenceBlock name="content.aside">
-            <block  class="Yotpo\Yotpo\Block\Yotpo" name="widget_div" template="widget_div.phtml"/>
+            <block  class="Yotpo\Yotpo\Block\Yotpo" name="yotpo_widget_div" template="widget_div.phtml"/>
         </referenceBlock> 
 
        <referenceContainer name="product.info.main">
          <referenceBlock name="reviews.tab" remove="true"/>
-            <block  class="Yotpo\Yotpo\Block\Yotpo" name="bottomline" as="other" template="bottomline.phtml" before="product.info.addto"/>
+            <block  class="Yotpo\Yotpo\Block\Yotpo" name="yotpo_bottomline" as="yotpo_other" template="bottomline.phtml" before="product.info.addto"/>
        </referenceContainer>
 
 		<!-- Add yotpo widget div to product page  -->


### PR DESCRIPTION
Resolves an issue where the `as="other"` alias from `Magento\Review\Block\Product\View\Other` clashes with this module's bottomline block definition.

This prevents errors such as this:
`Magento\Framework\Exception\LocalizedException: The element 'product.info.main' already has a child with alias 'other' ...`