### PR TITLE
Fix for issue #123.

### DIFF
--- a/view/frontend/layout/catalog_category_view.xml
+++ b/view/frontend/layout/catalog_category_view.xml
@@ -1,4 +1,4 @@
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
 		<css src="Yotpo_Yotpo::css/bottomline.css"/>			 
     </head>    

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,4 +1,4 @@
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
 		<css src="Yotpo_Yotpo::css/bottomline.css"/>			         
     </head>    

--- a/view/frontend/layout/cms_index_index.xml
+++ b/view/frontend/layout/cms_index_index.xml
@@ -1,4 +1,4 @@
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
 		<css src="Yotpo_Yotpo::css/bottomline.css"/>			         
     </head>    


### PR DESCRIPTION
As proposed in  #123, this PR removes all `layout` attributes from the layout files' `page` elements to prevent them overriding layouts for themes built on the base Magento theme.